### PR TITLE
Return same fields name as google endpoint

### DIFF
--- a/geocode.go
+++ b/geocode.go
@@ -111,6 +111,8 @@ type Result struct {
 	AddressParts []*AddressPart `json:"address_components"`
 	Geometry     *Geometry      `json:"geometry"`
 	Types        []string       `json:"types"`
+	PartialMatch bool           `json:"partial_match"`
+	PlaceId      string         `json:"place_id"`
 }
 
 type AddressPart struct {
@@ -120,7 +122,7 @@ type AddressPart struct {
 }
 
 type Geometry struct {
-	Bounds   Bounds `json:"bounds"`
+	Bounds   *Bounds `json:"bounds,omitempty"`
 	Location Point  `json:"location"`
 	Type     string `json:"location_type"`
 	Viewport Bounds `json:"viewport"`

--- a/geocode.go
+++ b/geocode.go
@@ -102,8 +102,8 @@ func (r *Request) GetUri() string {
 }
 
 type Response struct {
-	Status  string
-	Results []*Result
+	Status  string    `json:"status"`
+	Results []*Result `json:"results"`
 }
 
 type Result struct {
@@ -123,9 +123,9 @@ type AddressPart struct {
 
 type Geometry struct {
 	Bounds   *Bounds `json:"bounds,omitempty"`
-	Location Point  `json:"location"`
-	Type     string `json:"location_type"`
-	Viewport Bounds `json:"viewport"`
+	Location Point   `json:"location"`
+	Type     string  `json:"location_type"`
+	Viewport Bounds  `json:"viewport"`
 }
 
 type Bounds struct {

--- a/geocode.go
+++ b/geocode.go
@@ -111,8 +111,8 @@ type Result struct {
 	AddressParts []*AddressPart `json:"address_components"`
 	Geometry     *Geometry      `json:"geometry"`
 	Types        []string       `json:"types"`
-	PartialMatch bool           `json:"partial_match"`
-	PlaceId      string         `json:"place_id"`
+	PartialMatch bool           `json:"partial_match,omitempty"`
+	PlaceId      string         `json:"place_id,omitempty"`
 }
 
 type AddressPart struct {

--- a/geocode.go
+++ b/geocode.go
@@ -109,25 +109,26 @@ type Response struct {
 type Result struct {
 	Address      string         `json:"formatted_address"`
 	AddressParts []*AddressPart `json:"address_components"`
-	Geometry     *Geometry
-	Types        []string
+	Geometry     *Geometry      `json:"geometry"`
+	Types        []string       `json:"types"`
 }
 
 type AddressPart struct {
-	Name      string `json:"long_name"`
-	ShortName string `json:"short_name"`
-	Types     []string
+	Name      string   `json:"long_name"`
+	ShortName string   `json:"short_name"`
+	Types     []string `json:"types"`
 }
 
 type Geometry struct {
-	Bounds   Bounds
-	Location Point
-	Type     string
-	Viewport Bounds
+	Bounds   Bounds `json:"bounds"`
+	Location Point  `json:"location"`
+	Type     string `json:"location_type"`
+	Viewport Bounds `json:"viewport"`
 }
 
 type Bounds struct {
-	NorthEast, SouthWest Point
+	NorthEast Point `json:"northeast"`
+	SouthWest Point `json:"southwest"`
 }
 
 func (b Bounds) String() string {
@@ -135,7 +136,8 @@ func (b Bounds) String() string {
 }
 
 type Point struct {
-	Lat, Lng float64
+	Lat float64 `json:"lat"`
+	Lng float64 `json:"lng"`
 }
 
 func (p Point) String() string {

--- a/geocode_test.go
+++ b/geocode_test.go
@@ -1,99 +1,38 @@
 package geocode
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
-func TestLookup(t *testing.T) {
-	req := &Request{
-		Address: "New York City",
-	}
-	resp, err := req.Lookup(nil)
+// Make sure Bounds is not included in Geometry field, since it is an optional field
+func TestMarshallingResponseNoBounds(t *testing.T) {
+	googleResponse := []byte(`{"results": [ { "address_components": [ { "long_name": "1600", "short_name": "1600", "types": [ "street_number" ] }, { "long_name": "Amphitheatre Pkwy", "short_name": "Amphitheatre Pkwy", "types": [ "route" ] }, { "long_name": "Mountain View", "short_name": "Mountain View", "types": [ "locality", "political" ] }, { "long_name": "Santa Clara", "short_name": "Santa Clara", "types": [ "administrative_area_level_2", "political" ] }, { "long_name": "California", "short_name": "CA", "types": [ "administrative_area_level_1", "political" ] }, { "long_name": "United States", "short_name": "US", "types": [ "country", "political" ] }, { "long_name": "94043", "short_name": "94043", "types": [ "postal_code" ] } ], "formatted_address": "1600 Amphitheatre Pkwy, Mountain View, CA 94043, USA", "geometry": { "location": { "lat": 37.4229181, "lng": -122.0854212 }, "location_type": "ROOFTOP", "viewport": { "northeast": { "lat": 37.42426708029149, "lng": -122.0840722197085 }, "southwest": { "lat": 37.4215691197085, "lng": -122.0867701802915 } } }, "types": [ "street_address" ] } ], "status": "OK" }
+`)
+
+	resp := new(Response)
+	err := json.Unmarshal(googleResponse, resp)
 	if err != nil {
-		t.Fatalf("Lookup error: %v", err)
+		t.Fatalf("Decoding error: %v", err)
 	}
-	if s := resp.Status; s != "OK" {
-		t.Fatalf(`Status == %q, want "OK"`, s)
-	}
-	if l := len(resp.Results); l != 1 {
-		t.Fatalf("len(Results) == %d, want 1", l)
-	}
-	addr := "New York, NY, USA"
-	if a := resp.Results[0].Address; a != addr {
-		t.Errorf("Address == %q, want %q", a, addr)
-	}
-}
 
-func TestLookupWithGoogleCredential(t *testing.T) {
-	req := &Request{
-		Address:      "New York City",
-		Googleclient: "secret",
+	// Test it did basic marshal
+	if resp.Status != "OK" {
+		t.Errorf("Status == %q, want %q", resp.Status, "OK")
 	}
-	uri := req.GetUri()
-	if uri != "/maps/api/geocode/json?address=New+York+City&client=secret&sensor=false" {
-		t.Fatalf("Wrong response: %v", uri)
-	}
-}
 
-func TestLookupWithBounds(t *testing.T) {
-	req := &Request{
-		Address: "Winnetka",
+	// Make sure no bounds is found because is optional
+	for _, addr := range resp.Results {
+		if addr.Geometry.Bounds != nil {
+			t.Errorf("Bounds found, do not want: %v", addr)
+		}
 	}
-	bounds := &Bounds{Point{34.172684, -118.604794},
-		Point{34.236144, -118.500938}}
-	req.Bounds = bounds
-	resp, err := req.Lookup(nil)
-	if err != nil {
-		t.Fatalf("Lookup error: %v", err)
-	}
-	if s := resp.Status; s != "OK" {
-		t.Fatalf(`Status == %q, want "OK"`, s)
-	}
-	if l := len(resp.Results); l != 1 {
-		t.Fatalf("len(Results) == %d, want 1", l)
-	}
-	addr := "Winnetka, Los Angeles, CA, USA"
-	if a := resp.Results[0].Address; a != addr {
-		t.Errorf("Address == %q, want %q", a, addr)
-	}
-}
 
-func TestLookupWithLanguage(t *testing.T) {
-	req := &Request{
-		Address: "札幌市",
-	}
-	req.Language = "ja"
-	resp, err := req.Lookup(nil)
-	if err != nil {
-		t.Fatalf("Lookup error: %v", err)
-	}
-	if s := resp.Status; s != "OK" {
-		t.Fatalf(`Status == %q, want "OK"`, s)
-	}
-	if l := len(resp.Results); l != 1 {
-		t.Fatalf("len(Results) == %d, want 1", l)
-	}
-	addr := "日本, 北海道札幌市"
-	if a := resp.Results[0].Address; a != addr {
-		t.Errorf("Address == %q, want %q", a, addr)
-	}
-}
+	b, err := json.Marshal(resp)
+	// blind test, but make sure keys are all lower case
+	expectedResponse := `{"status":"OK","results":[{"formatted_address":"1600 Amphitheatre Pkwy, Mountain View, CA 94043, USA","address_components":[{"long_name":"1600","short_name":"1600","types":["street_number"]},{"long_name":"Amphitheatre Pkwy","short_name":"Amphitheatre Pkwy","types":["route"]},{"long_name":"Mountain View","short_name":"Mountain View","types":["locality","political"]},{"long_name":"Santa Clara","short_name":"Santa Clara","types":["administrative_area_level_2","political"]},{"long_name":"California","short_name":"CA","types":["administrative_area_level_1","political"]},{"long_name":"United States","short_name":"US","types":["country","political"]},{"long_name":"94043","short_name":"94043","types":["postal_code"]}],"geometry":{"location":{"lat":37.4229181,"lng":-122.0854212},"location_type":"ROOFTOP","viewport":{"northeast":{"lat":37.42426708029149,"lng":-122.0840722197085},"southwest":{"lat":37.4215691197085,"lng":-122.0867701802915}}},"types":["street_address"]}]}`
 
-func TestLookupWithRegion(t *testing.T) {
-	req := &Request{
-		Address: "Toledo",
-	}
-	req.Region = "es"
-	resp, err := req.Lookup(nil)
-	if err != nil {
-		t.Fatalf("Lookup error: %v", err)
-	}
-	if s := resp.Status; s != "OK" {
-		t.Fatalf(`Status == %q, want "OK"`, s)
-	}
-	if l := len(resp.Results); l != 1 {
-		t.Fatalf("len(Results) == %d, want 1", l)
-	}
-	addr := "Toledo, Spain"
-	if a := resp.Results[0].Address; a != addr {
-		t.Errorf("Address == %q, want %q", a, addr)
+	if string(b) != expectedResponse {
+		t.Errorf("Expected JSON is not correct: %s", b)
 	}
 }


### PR DESCRIPTION
We seems to be returning different response with the google endpoint because of the missing json annotations (when calling json.Marshal on the go object)
